### PR TITLE
Detailed Explanation of Markdown Hint Implementation

### DIFF
--- a/src/pages/Ideas.jsx
+++ b/src/pages/Ideas.jsx
@@ -6,7 +6,7 @@ import useAuthStore from '../store/useAuthStore';
 import useIdeasStore from '../store/useIdeasStore';
 import FloatingButton from '../components/FloatingButton';
 import Fuse from 'fuse.js';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Info, Pencil, Trash2 } from 'lucide-react';
 import { setPageSEO } from '../utils/seo.js';
 
 function Ideas() {
@@ -110,21 +110,31 @@ function Ideas() {
       value={newTitle}
       onChange={(e) => setNewTitle(e.target.value)}
       placeholder="New idea title..."
-      className="flex-1 px-2 sm:px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/70 dark:bg-gray-900/70 text-black dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 text-xs sm:text-base"
+      className="flex-1 px-2 sm:px-4 py-2 rounded-lg border self-start border-gray-300 dark:border-gray-700 bg-white/70 dark:bg-gray-900/70 text-black dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 text-xs sm:text-base"
       disabled={loading}
       required
     />
-    <input
-      type="text"
-      value={newDesc}
-      onChange={(e) => setNewDesc(e.target.value)}
-      placeholder="Description (optional)"
-      className="flex-1 px-2 sm:px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/70 dark:bg-gray-900/70 text-black dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 text-xs sm:text-base"
-      disabled={loading}
-    />
+    <div className="flex flex-col-reverse gap-2 mb-2">
+      <label className="flex sm:items-center text-xs gap-1" htmlFor="idea">
+        <Info className="w-3 h-3 pt-0.5 sm:pt-0"/>            
+        <span className="text-wrap">
+          You can use Markdown for formatting (<em>italic</em>, <strong>bold</strong>, <code className='bg-gray-800 px-1 py-0.5 rounded-md'>code</code>)
+        </span>
+      </label>
+      <input
+        name="idea"
+        id="idea"
+        type="text"
+        value={newDesc}
+        onChange={(e) => setNewDesc(e.target.value)}
+        placeholder="Description (optional)"
+        className="flex-1 px-2 sm:px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/70 dark:bg-gray-900/70 text-black dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 text-xs sm:text-base"
+        disabled={loading}
+        />
+      </div>
     <button
       type="submit"
-      className="bg-purple-600 text-white px-4 sm:px-6 py-2 rounded-lg font-semibold hover:bg-purple-700 transition-colors text-xs sm:text-base"
+      className="bg-purple-600 self-start text-white px-4 sm:px-6 py-2 rounded-lg font-semibold hover:bg-purple-700 transition-colors text-xs sm:text-base"
       disabled={loading}
     >
       Add

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -6,7 +6,7 @@ import useAuthStore from '../store/useAuthStore';
 import useSearchStore from '../store/useSearchStore';
 import useTasksStore from '../store/useTasksStore';
 import Fuse from 'fuse.js';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Info, Pencil, Trash2 } from 'lucide-react';
 import { setPageSEO } from '../utils/seo.js';
 
 function Tasks() {
@@ -109,23 +109,33 @@ function Tasks() {
         onSubmit={e => { e.preventDefault(); handleAddTask(); }}
         className="flex flex-col sm:flex-row gap-2 sm:gap-4 mb-6 sm:mb-8"
       >
-        <input
-          type="text"
-          placeholder="New task..."
-          value={newTask}
-          onChange={(e) => setNewTask(e.target.value)}
-          onKeyDown={(e) => {
-          if (e.key === 'Enter' && !e.shiftKey) {
-            e.preventDefault();
-            handleAddTask();
-          }
-        }}
-          className="flex-1 px-2 sm:px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/70 dark:bg-gray-900/70 text-black dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 text-xs sm:text-base"
-          required
-        />
+        <div className="flex flex-col-reverse w-full gap-2 mb-2">
+          <label className="flex sm:items-center text-xs gap-1" htmlFor="task">
+            <Info className="w-3 h-3 pt-0.5 sm:pt-0"/>            
+            <span className="text-wrap">
+              You can use Markdown for formatting (<em>italic</em>, <strong>bold</strong>, <code className='bg-gray-800 px-1 py-0.5 rounded-md'>code</code>)
+            </span>
+          </label>
+          <input
+            type="text"
+            name="task"
+            id="task"
+            placeholder="New task..."
+            value={newTask}
+            onChange={(e) => setNewTask(e.target.value)}
+            onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              handleAddTask();
+            }
+          }}
+            className="flex-1 px-2 sm:px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/70 dark:bg-gray-900/70 text-black dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 text-xs sm:text-base"
+            required
+          />
+        </div>
         <button
           type="submit"
-          className="bg-purple-600 text-white px-4 sm:px-6 py-2 rounded-lg font-semibold hover:bg-purple-700 transition-colors text-xs sm:text-base"
+          className="bg-purple-600 self-start text-white px-4 sm:px-6 py-2 rounded-lg font-semibold hover:bg-purple-700 transition-colors text-xs sm:text-base"
           disabled={loading}
         >
           Add

--- a/src/pages/Thoughts.jsx
+++ b/src/pages/Thoughts.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { motion } from 'framer-motion';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Info, Pencil, Trash2 } from 'lucide-react';
 import { parseText } from '../utils/parseText';
 import useSearchStore from '../store/useSearchStore';
 import useAuthStore from '../store/useAuthStore';
@@ -89,17 +89,27 @@ function Thoughts() {
         onSubmit={e => { e.preventDefault(); handleAddThought(); }}
         className="flex flex-col sm:flex-row gap-2 sm:gap-4 mb-6 sm:mb-8"
       >
-        <input
-          type="text"
-          placeholder="New thought..."
-          value={newThought}
-          onChange={e => setNewThought(e.target.value)}
-          className="flex-1 px-2 sm:px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/70 dark:bg-gray-900/70 text-black dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 text-xs sm:text-base"
-          required
-        />
+        <div className="flex flex-col-reverse w-full gap-2 mb-2">
+          <label className="flex sm:items-center text-xs gap-1" htmlFor="thought">
+            <Info className="w-3 h-3 pt-0.5 sm:pt-0"/>            
+            <span className="text-wrap">
+              You can use Markdown for formatting (<em>italic</em>, <strong>bold</strong>, <code className="bg-gray-800 px-1 py-0.5 rounded-md">code</code>)
+            </span>
+          </label>
+          <input
+            id="thought"
+            name="thought"
+            type="text"
+            placeholder="New thought..."
+            value={newThought}
+            onChange={e => setNewThought(e.target.value)}
+            className="flex-1 px-2 sm:px-4 py-2 rounded-lg border border-gray-300 dark:border-gray-700 bg-white/70 dark:bg-gray-900/70 text-black dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 text-xs sm:text-base"
+            required
+          />
+        </div>
         <button
           type="submit"
-          className="bg-purple-600 text-white px-4 sm:px-6 py-2 rounded-lg font-semibold hover:bg-purple-700 transition-colors text-xs sm:text-base"
+          className="bg-purple-600 self-start text-white px-4 sm:px-6 py-2 rounded-lg font-semibold hover:bg-purple-700 transition-colors text-xs sm:text-base"
           disabled={loading}
         >
           Add


### PR DESCRIPTION
## Summary 
Added a new wrapper `<div>` to group the input and its associated hint for better layout control. Introduced a `<label>` containing an info icon to indicate helpful information about Markdown formatting. 

The hint reads:  "You can use Markdown for formatting (_italic_, **bold**, `code`)". 

The label is linked to the input via `htmlFor` for accessibility. The button styling was adjusted with `self-start` to prevent unwanted stretching and maintain proper alignment.

## Files Edited  
- `src/pages/Thoughts.jsx`  
- `src/pages/Ideas.jsx`  
- `src/pages/Tasks.jsx`  





Closes #5 